### PR TITLE
Minor doc typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ EM.run do
       shell.expect('~]$ ', '/sbin/ifconfig -a')
       EM.stop
     end
-    shell.errback do
+    shell.errback do |err|
       puts "error: #{err} (#{err.class})" 
       EM.stop
     end


### PR DESCRIPTION
Error callback in shell example needs to be passed the error :-)
