### PR TITLE
em-ssh throws exception when no logger is defined

### DIFF
--- a/lib/em-ssh/connection/channel/null-logger.rb
+++ b/lib/em-ssh/connection/channel/null-logger.rb
@@ -6,6 +6,10 @@ module EventMachine
       class Channel
         class NullLogger < ::Logger
 
+          def initialize
+            super(nil)
+          end
+
           def add(*params, &block)
             nil
           end


### PR DESCRIPTION
Closes issue #21.
