### PR TITLE
Callbacks defined on EM::Ssh::Shell don't work

### DIFF
--- a/lib/em-ssh/callbacks.rb
+++ b/lib/em-ssh/callbacks.rb
@@ -25,6 +25,10 @@ module EventMachine
         @clbks ||= {}
       end # callbacks
 
+      def callbacks=(clbks)
+        @clbks = clbks
+      end
+
 
       # Signal that an event has occured.
       # Each callback will receive whatever args are passed to fire, or the object that the event was fired upon.

--- a/lib/em-ssh/shell.rb
+++ b/lib/em-ssh/shell.rb
@@ -183,6 +183,8 @@ module EventMachine
                   @closed = false
                   @shell  = shell
                   shell.extend(EventMachine::Ssh::Connection::Channel::Interactive)
+                  # Share callbacks with shell
+                  send(:callbacks=, shell.callbacks)
                   shell.line_terminator = @line_terminator if @line_terminator
                   shell.on(:data) { |data| debug("#{shell.dump_buffer}") }
                   set_open_status(self)


### PR DESCRIPTION
Callbacks defined on EM::Ssh::Shell objects should be defined on its `@shell` instance variable as well.
